### PR TITLE
feat(costs): port pure helpers from upstream costs API

### DIFF
--- a/src/pynapse/payments/__init__.py
+++ b/src/pynapse/payments/__init__.py
@@ -1,3 +1,9 @@
+from .calculations import (
+    AccountStateInputs,
+    ResolvedAccountState,
+    calculate_account_debt,
+    resolve_account_state,
+)
 from .service import (
     AccountInfo,
     AsyncPaymentsService,
@@ -9,9 +15,13 @@ from .service import (
 
 __all__ = [
     "AccountInfo",
+    "AccountStateInputs",
     "AsyncPaymentsService",
     "RailInfo",
+    "ResolvedAccountState",
     "ServiceApproval",
     "SettlementResult",
     "SyncPaymentsService",
+    "calculate_account_debt",
+    "resolve_account_state",
 ]

--- a/src/pynapse/payments/calculations.py
+++ b/src/pynapse/payments/calculations.py
@@ -1,0 +1,76 @@
+"""Pure account-state and debt calculations mirroring the Payments contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+MAX_UINT256 = (1 << 256) - 1
+
+
+@dataclass(frozen=True)
+class AccountStateInputs:
+    funds: int
+    lockup_current: int
+    lockup_rate: int
+    lockup_last_settled_at: int
+    current_epoch: int
+
+
+@dataclass(frozen=True)
+class ResolvedAccountState:
+    funded_until_epoch: int
+    available_funds: int
+
+
+def _as_inputs(params: AccountStateInputs | dict) -> AccountStateInputs:
+    if isinstance(params, AccountStateInputs):
+        return params
+    return AccountStateInputs(**params)
+
+
+def calculate_account_debt(params: AccountStateInputs | dict) -> int:
+    """Compute account debt — the unsettled lockup amount exceeding funds."""
+    p = _as_inputs(params)
+    elapsed = p.current_epoch - p.lockup_last_settled_at
+    total_owed = p.lockup_current + p.lockup_rate * elapsed
+    return max(0, total_owed - p.funds)
+
+
+def resolve_account_state(params: AccountStateInputs | dict) -> ResolvedAccountState:
+    """Project account state forward to ``current_epoch`` via simulated settlement.
+
+    Pure function — no RPC call. Mirrors the contract-side computation of
+    ``fundedUntilEpoch`` and ``availableFunds``.
+    """
+    p = _as_inputs(params)
+
+    if p.lockup_rate == 0:
+        funded_until_epoch = MAX_UINT256
+    else:
+        # Integer division — JS bigint uses truncation toward zero, matching
+        # Python's behavior only for non-negative operands. The JS source
+        # allows negative numerators (funds < lockup_current), which Python
+        # would round toward -inf. Emulate JS truncation explicitly.
+        numerator = p.funds - p.lockup_current
+        quotient = _trunc_div(numerator, p.lockup_rate)
+        funded_until_epoch = p.lockup_last_settled_at + quotient
+
+    simulated_settled_at = min(funded_until_epoch, p.current_epoch)
+    simulated_lockup_current = p.lockup_current + p.lockup_rate * (
+        simulated_settled_at - p.lockup_last_settled_at
+    )
+    raw_available = p.funds - simulated_lockup_current
+    available_funds = max(0, raw_available)
+
+    return ResolvedAccountState(
+        funded_until_epoch=funded_until_epoch,
+        available_funds=available_funds,
+    )
+
+
+def _trunc_div(a: int, b: int) -> int:
+    """Truncated division (toward zero) to match JS bigint semantics."""
+    q, r = divmod(a, b)
+    if r != 0 and (a < 0) != (b < 0):
+        q += 1
+    return q

--- a/src/pynapse/warm_storage/__init__.py
+++ b/src/pynapse/warm_storage/__init__.py
@@ -4,6 +4,11 @@ from .calculations import (
     calculate_additional_lockup_required,
     calculate_effective_rate,
 )
+from .deposit import (
+    calculate_buffer_amount,
+    calculate_deposit_needed,
+    calculate_runway_amount,
+)
 from .service import (
     AsyncWarmStorageService,
     DataSetInfo,
@@ -20,4 +25,7 @@ __all__ = [
     "EffectiveRate",
     "calculate_additional_lockup_required",
     "calculate_effective_rate",
+    "calculate_buffer_amount",
+    "calculate_deposit_needed",
+    "calculate_runway_amount",
 ]

--- a/src/pynapse/warm_storage/deposit.py
+++ b/src/pynapse/warm_storage/deposit.py
@@ -1,0 +1,96 @@
+"""Deposit/runway/buffer calculations mirroring warm-storage costs API."""
+
+from __future__ import annotations
+
+from ..core.constants import (
+    DEFAULT_BUFFER_EPOCHS,
+    DEFAULT_RUNWAY_EPOCHS,
+    LOCKUP_PERIOD,
+    TIME_CONSTANTS,
+)
+from .calculations import calculate_additional_lockup_required
+
+
+def calculate_runway_amount(*, net_rate_after_upload: int, extra_runway_epochs: int) -> int:
+    """Extra funds to keep the account funded beyond the lockup period.
+
+    Uses the net rate (current + delta) so the runway covers the full drain
+    rate after the new rail is created.
+    """
+    return net_rate_after_upload * extra_runway_epochs
+
+
+def calculate_buffer_amount(
+    *,
+    raw_deposit_needed: int,
+    net_rate_after_upload: int,
+    funded_until_epoch: int,
+    current_epoch: int,
+    available_funds: int,
+    buffer_epochs: int,
+) -> int:
+    """Safety margin for epoch drift between balance check and tx execution."""
+    if raw_deposit_needed > 0:
+        return net_rate_after_upload * buffer_epochs
+
+    if funded_until_epoch <= current_epoch + buffer_epochs:
+        buffer_cost = net_rate_after_upload * buffer_epochs
+        return max(0, buffer_cost - available_funds)
+
+    return 0
+
+
+def calculate_deposit_needed(
+    *,
+    data_size: int,
+    current_data_set_size: int,
+    price_per_tib_per_month: int,
+    minimum_price_per_month: int,
+    is_new_data_set: bool,
+    with_cdn: bool,
+    current_lockup_rate: int,
+    debt: int,
+    available_funds: int,
+    funded_until_epoch: int,
+    current_epoch: int,
+    epochs_per_month: int = TIME_CONSTANTS["EPOCHS_PER_MONTH"],
+    lockup_epochs: int = LOCKUP_PERIOD,
+    extra_runway_epochs: int = DEFAULT_RUNWAY_EPOCHS,
+    buffer_epochs: int = DEFAULT_BUFFER_EPOCHS,
+) -> int:
+    """Orchestrate lockup + runway + debt + buffer for total deposit needed."""
+    lockup = calculate_additional_lockup_required(
+        data_size=data_size,
+        current_data_set_size=current_data_set_size,
+        price_per_tib_per_month=price_per_tib_per_month,
+        minimum_price_per_month=minimum_price_per_month,
+        epochs_per_month=epochs_per_month,
+        lockup_epochs=lockup_epochs,
+        is_new_data_set=is_new_data_set,
+        with_cdn=with_cdn,
+    )
+
+    net_rate_after_upload = current_lockup_rate + lockup.rate_delta_per_epoch
+    runway = calculate_runway_amount(
+        net_rate_after_upload=net_rate_after_upload,
+        extra_runway_epochs=extra_runway_epochs,
+    )
+    raw_deposit_needed = lockup.total + runway + debt - available_funds
+
+    # Skip buffer when no existing rails are draining and this is a new
+    # dataset — the deposit lands before any rail is created.
+    skip_buffer = current_lockup_rate == 0 and is_new_data_set
+
+    buffer = 0
+    if not skip_buffer:
+        buffer = calculate_buffer_amount(
+            raw_deposit_needed=raw_deposit_needed,
+            net_rate_after_upload=net_rate_after_upload,
+            funded_until_epoch=funded_until_epoch,
+            current_epoch=current_epoch,
+            available_funds=available_funds,
+            buffer_epochs=buffer_epochs,
+        )
+
+    clamped = max(0, raw_deposit_needed)
+    return clamped + buffer

--- a/tests/test_account_state.py
+++ b/tests/test_account_state.py
@@ -1,0 +1,110 @@
+"""Tests mirroring upstream account-debt.test.ts."""
+
+from __future__ import annotations
+
+from pynapse.payments.calculations import (
+    MAX_UINT256,
+    calculate_account_debt,
+    resolve_account_state,
+)
+
+
+def test_resolve_healthy_account():
+    result = resolve_account_state(
+        {
+            "funds": 1000,
+            "lockup_current": 100,
+            "lockup_rate": 1,
+            "lockup_last_settled_at": 0,
+            "current_epoch": 100,
+        }
+    )
+    assert result.funded_until_epoch == 900
+    assert result.available_funds == 800
+
+
+def test_resolve_underfunded_account():
+    result = resolve_account_state(
+        {
+            "funds": 100,
+            "lockup_current": 200,
+            "lockup_rate": 2,
+            "lockup_last_settled_at": 1000,
+            "current_epoch": 1200,
+        }
+    )
+    assert result.funded_until_epoch == 950
+    assert result.available_funds == 0
+
+
+def test_resolve_partially_funded_runs_out_before_current_epoch():
+    result = resolve_account_state(
+        {
+            "funds": 100,
+            "lockup_current": 50,
+            "lockup_rate": 1,
+            "lockup_last_settled_at": 0,
+            "current_epoch": 200,
+        }
+    )
+    assert result.funded_until_epoch == 50
+    assert result.available_funds == 0
+
+
+def test_resolve_zero_rate_returns_max_uint256():
+    result = resolve_account_state(
+        {
+            "funds": 1000,
+            "lockup_current": 100,
+            "lockup_rate": 0,
+            "lockup_last_settled_at": 0,
+            "current_epoch": 100,
+        }
+    )
+    assert result.funded_until_epoch == MAX_UINT256
+    assert result.available_funds == 900
+
+
+def test_debt_healthy_account_is_zero():
+    assert (
+        calculate_account_debt(
+            {
+                "funds": 1000,
+                "lockup_current": 100,
+                "lockup_rate": 1,
+                "lockup_last_settled_at": 0,
+                "current_epoch": 100,
+            }
+        )
+        == 0
+    )
+
+
+def test_debt_underfunded_account_is_positive():
+    assert (
+        calculate_account_debt(
+            {
+                "funds": 100,
+                "lockup_current": 50,
+                "lockup_rate": 1,
+                "lockup_last_settled_at": 0,
+                "current_epoch": 200,
+            }
+        )
+        == 150
+    )
+
+
+def test_debt_zero_rate_is_zero():
+    assert (
+        calculate_account_debt(
+            {
+                "funds": 1000,
+                "lockup_current": 100,
+                "lockup_rate": 0,
+                "lockup_last_settled_at": 0,
+                "current_epoch": 100,
+            }
+        )
+        == 0
+    )

--- a/tests/test_deposit_needed.py
+++ b/tests/test_deposit_needed.py
@@ -1,0 +1,153 @@
+"""Tests mirroring upstream calculate-deposit-needed.test.ts."""
+
+from __future__ import annotations
+
+from pynapse.payments.calculations import MAX_UINT256
+from pynapse.warm_storage.deposit import (
+    calculate_buffer_amount,
+    calculate_deposit_needed,
+    calculate_runway_amount,
+)
+
+PRICING = {
+    "price_per_tib_per_month": 2_500_000_000_000_000_000,
+    "minimum_price_per_month": 60_000_000_000_000_000,
+    "epochs_per_month": 86400,
+}
+
+
+def test_runway_amount():
+    assert (
+        calculate_runway_amount(net_rate_after_upload=15, extra_runway_epochs=100)
+        == 1500
+    )
+
+
+def test_buffer_with_positive_raw_deposit():
+    result = calculate_buffer_amount(
+        raw_deposit_needed=100,
+        net_rate_after_upload=15,
+        funded_until_epoch=500,
+        current_epoch=100,
+        available_funds=200,
+        buffer_epochs=20,
+    )
+    assert result == 300
+
+
+def test_buffer_with_positive_raw_no_delta():
+    result = calculate_buffer_amount(
+        raw_deposit_needed=100,
+        net_rate_after_upload=10,
+        funded_until_epoch=500,
+        current_epoch=100,
+        available_funds=200,
+        buffer_epochs=20,
+    )
+    assert result == 200
+
+
+def test_buffer_negative_raw_within_buffer_window():
+    result = calculate_buffer_amount(
+        raw_deposit_needed=-50,
+        net_rate_after_upload=15,
+        funded_until_epoch=110,
+        current_epoch=100,
+        available_funds=50,
+        buffer_epochs=20,
+    )
+    assert result == 250
+
+
+def test_buffer_negative_raw_beyond_buffer_window():
+    result = calculate_buffer_amount(
+        raw_deposit_needed=-50,
+        net_rate_after_upload=15,
+        funded_until_epoch=500,
+        current_epoch=100,
+        available_funds=200,
+        buffer_epochs=20,
+    )
+    assert result == 0
+
+
+def test_deposit_healthy_account_returns_zero():
+    assert (
+        calculate_deposit_needed(
+            data_size=1000,
+            current_data_set_size=0,
+            **PRICING,
+            lockup_epochs=86400,
+            is_new_data_set=True,
+            with_cdn=False,
+            current_lockup_rate=0,
+            extra_runway_epochs=0,
+            debt=0,
+            available_funds=100_000_000_000_000_000_000,
+            funded_until_epoch=MAX_UINT256,
+            current_epoch=1000,
+            buffer_epochs=10,
+        )
+        == 0
+    )
+
+
+def test_deposit_new_dataset_no_existing_rails_skips_buffer():
+    base = dict(
+        data_size=1000,
+        current_data_set_size=0,
+        **PRICING,
+        lockup_epochs=86400,
+        is_new_data_set=True,
+        with_cdn=False,
+        current_lockup_rate=0,
+        extra_runway_epochs=0,
+        debt=0,
+        available_funds=0,
+        funded_until_epoch=0,
+        current_epoch=1000,
+    )
+    with_buffer = calculate_deposit_needed(**base, buffer_epochs=100)
+    without_buffer = calculate_deposit_needed(**base, buffer_epochs=0)
+    assert with_buffer == without_buffer
+    assert with_buffer > 0
+
+
+def test_deposit_new_dataset_with_existing_rails_applies_buffer():
+    base = dict(
+        data_size=1000,
+        current_data_set_size=0,
+        **PRICING,
+        lockup_epochs=86400,
+        is_new_data_set=True,
+        with_cdn=False,
+        current_lockup_rate=100_000_000_000_000,
+        extra_runway_epochs=0,
+        debt=0,
+        available_funds=0,
+        funded_until_epoch=0,
+        current_epoch=1000,
+    )
+    with_buffer = calculate_deposit_needed(**base, buffer_epochs=100)
+    without_buffer = calculate_deposit_needed(**base, buffer_epochs=0)
+    assert with_buffer > without_buffer
+
+
+def test_deposit_underfunded_includes_debt():
+    debt = 5_000_000_000_000_000_000
+    result = calculate_deposit_needed(
+        data_size=1000,
+        current_data_set_size=0,
+        **PRICING,
+        lockup_epochs=86400,
+        is_new_data_set=True,
+        with_cdn=False,
+        current_lockup_rate=10,
+        extra_runway_epochs=0,
+        debt=debt,
+        available_funds=0,
+        funded_until_epoch=50,
+        current_epoch=1000,
+        buffer_epochs=10,
+    )
+    assert result >= debt


### PR DESCRIPTION
## Summary
Mirrors the pure-function core of [FilOzone/synapse-sdk#632](https://github.com/FilOzone/synapse-sdk/pull/632).

- `payments/calculations.py`: `calculate_account_debt`, `resolve_account_state` (with JS-bigint-compatible truncated division).
- `warm_storage/deposit.py`: `calculate_runway_amount`, `calculate_buffer_amount`, `calculate_deposit_needed` — orchestrates lockup + runway + debt + buffer. Uses the sybil fee and CDN fixed lockup from the previous PR.

Higher-level async/sync orchestrators (`get_upload_costs`, `fund`, `deposit_with_permit`, `get_account_summary`) that require live RPC calls can be added in a follow-up. These pure helpers already cover the client-side cost math that callers need.

## Test plan
- [x] `uv run pytest` — 75 passed (16 new).
- [x] Parity with upstream `calculate-deposit-needed.test.ts` and `account-debt.test.ts` cases.