### PR TITLE
feat(storage)!: thread source through Synapse for dataset namespace isolation

### DIFF
--- a/src/pynapse/storage/async_context.py
+++ b/src/pynapse/storage/async_context.py
@@ -56,6 +56,9 @@ class AsyncStorageContextOptions:
     force_create_data_set: bool = False
     metadata: Optional[Dict[str, str]] = None
     exclude_provider_ids: Optional[List[int]] = None
+    # Application identifier for dataset namespace isolation. When set, only
+    # datasets with a matching ``source`` metadata value are reused.
+    source: Optional[str] = None
     # Async callbacks
     on_provider_selected: Optional[Callable[["ProviderInfo"], Awaitable[None]]] = None
     on_data_set_resolved: Optional[Callable[[dict], Awaitable[None]]] = None
@@ -159,7 +162,9 @@ class AsyncStorageContext:
         client_address = acct.address
         
         options = options or AsyncStorageContextOptions()
-        requested_metadata = combine_metadata(options.metadata, options.with_cdn)
+        requested_metadata = combine_metadata(
+            options.metadata, options.with_cdn, options.source
+        )
         
         # Resolve provider and dataset
         resolution = await cls._resolve_provider_and_data_set(

--- a/src/pynapse/storage/async_manager.py
+++ b/src/pynapse/storage/async_manager.py
@@ -112,20 +112,27 @@ class AsyncStorageManager:
     """
     
     def __init__(
-        self, 
-        chain, 
+        self,
+        chain,
         private_key: str,
         sp_registry: Optional["AsyncSPRegistryService"] = None,
         warm_storage: Optional["AsyncWarmStorageService"] = None,
         retriever: Optional["AsyncChainRetriever"] = None,
+        source: Optional[str] = None,
     ) -> None:
         self._chain = chain
         self._private_key = private_key
         self._sp_registry = sp_registry
         self._warm_storage = warm_storage
         self._retriever = retriever
+        self._source = source
         self._default_context: Optional[AsyncStorageContext] = None
         self._context_cache: Dict[int, AsyncStorageContext] = {}  # provider_id -> context
+
+    @property
+    def source(self) -> Optional[str]:
+        """Application identifier for dataset namespace isolation."""
+        return self._source
 
     def create_context(
         self, 
@@ -155,6 +162,7 @@ class AsyncStorageManager:
         force_create_data_set: bool = False,
         metadata: Optional[Dict[str, str]] = None,
         exclude_provider_ids: Optional[List[int]] = None,
+        source: Optional[str] = None,
         on_provider_selected: Optional[Callable] = None,
         on_data_set_resolved: Optional[Callable] = None,
     ) -> AsyncStorageContext:
@@ -192,13 +200,15 @@ class AsyncStorageManager:
             and self._default_context is not None
         )
         
+        effective_source = source if source is not None else self._source
+
         if can_use_default:
             # Check if metadata matches
             from pynapse.utils.metadata import combine_metadata, metadata_matches
-            requested_metadata = combine_metadata(metadata, with_cdn)
+            requested_metadata = combine_metadata(metadata, with_cdn, effective_source)
             if metadata_matches(self._default_context.data_set_metadata, requested_metadata):
                 return self._default_context
-        
+
         # Create new context using factory method
         options = AsyncStorageContextOptions(
             provider_id=provider_id,
@@ -208,6 +218,7 @@ class AsyncStorageManager:
             force_create_data_set=force_create_data_set,
             metadata=metadata,
             exclude_provider_ids=exclude_provider_ids,
+            source=effective_source,
             on_provider_selected=on_provider_selected,
             on_data_set_resolved=on_data_set_resolved,
         )
@@ -233,6 +244,7 @@ class AsyncStorageManager:
         force_create_data_set: bool = False,
         metadata: Optional[Dict[str, str]] = None,
         exclude_provider_ids: Optional[List[int]] = None,
+        source: Optional[str] = None,
         on_provider_selected: Optional[Callable] = None,
         on_data_set_resolved: Optional[Callable] = None,
     ) -> List[AsyncStorageContext]:
@@ -256,15 +268,17 @@ class AsyncStorageManager:
         if self._sp_registry is None:
             raise ValueError("sp_registry required for smart context creation")
         
+        effective_source = source if source is not None else self._source
         options = AsyncStorageContextOptions(
             with_cdn=with_cdn,
             force_create_data_set=force_create_data_set,
             metadata=metadata,
             exclude_provider_ids=exclude_provider_ids,
+            source=effective_source,
             on_provider_selected=on_provider_selected,
             on_data_set_resolved=on_data_set_resolved,
         )
-        
+
         return await AsyncStorageContext.create_contexts(
             chain=self._chain,
             private_key=self._private_key,

--- a/src/pynapse/storage/context.py
+++ b/src/pynapse/storage/context.py
@@ -49,7 +49,7 @@ class ProviderSelectionResult:
     metadata: Dict[str, str] = field(default_factory=dict)
 
 
-@dataclass 
+@dataclass
 class StorageContextOptions:
     """Options for creating a storage context."""
     provider_id: Optional[int] = None
@@ -59,6 +59,9 @@ class StorageContextOptions:
     force_create_data_set: bool = False
     metadata: Optional[Dict[str, str]] = None
     exclude_provider_ids: Optional[List[int]] = None
+    # Application identifier for dataset namespace isolation. When set, only
+    # datasets with a matching ``source`` metadata value are reused.
+    source: Optional[str] = None
     # Callbacks
     on_provider_selected: Optional[Callable[["ProviderInfo"], None]] = None
     on_data_set_resolved: Optional[Callable[[dict], None]] = None
@@ -153,7 +156,9 @@ class StorageContext:
         client_address = acct.address
         
         options = options or StorageContextOptions()
-        requested_metadata = combine_metadata(options.metadata, options.with_cdn)
+        requested_metadata = combine_metadata(
+            options.metadata, options.with_cdn, options.source
+        )
         
         # Resolve provider and dataset
         resolution = cls._resolve_provider_and_data_set(

--- a/src/pynapse/storage/manager.py
+++ b/src/pynapse/storage/manager.py
@@ -106,20 +106,27 @@ class StorageManager:
     """
     
     def __init__(
-        self, 
-        chain, 
+        self,
+        chain,
         private_key: str,
         sp_registry=None,
         warm_storage=None,
         retriever=None,
+        source: Optional[str] = None,
     ) -> None:
         self._chain = chain
         self._private_key = private_key
         self._sp_registry = sp_registry
         self._warm_storage = warm_storage
         self._retriever = retriever
+        self._source = source
         self._default_context: Optional[StorageContext] = None
         self._context_cache: Dict[int, StorageContext] = {}  # provider_id -> context
+
+    @property
+    def source(self) -> Optional[str]:
+        """Application identifier for dataset namespace isolation."""
+        return self._source
 
     def create_context(
         self, 
@@ -149,6 +156,7 @@ class StorageManager:
         force_create_data_set: bool = False,
         metadata: Optional[Dict[str, str]] = None,
         exclude_provider_ids: Optional[List[int]] = None,
+        source: Optional[str] = None,
         on_provider_selected: Optional[Callable] = None,
         on_data_set_resolved: Optional[Callable] = None,
     ) -> StorageContext:
@@ -186,13 +194,15 @@ class StorageManager:
             and self._default_context is not None
         )
         
+        effective_source = source if source is not None else self._source
+
         if can_use_default:
             # Check if metadata matches
             from pynapse.utils.metadata import combine_metadata, metadata_matches
-            requested_metadata = combine_metadata(metadata, with_cdn)
+            requested_metadata = combine_metadata(metadata, with_cdn, effective_source)
             if metadata_matches(self._default_context.data_set_metadata, requested_metadata):
                 return self._default_context
-        
+
         # Create new context using factory method
         options = StorageContextOptions(
             provider_id=provider_id,
@@ -202,6 +212,7 @@ class StorageManager:
             force_create_data_set=force_create_data_set,
             metadata=metadata,
             exclude_provider_ids=exclude_provider_ids,
+            source=effective_source,
             on_provider_selected=on_provider_selected,
             on_data_set_resolved=on_data_set_resolved,
         )
@@ -227,6 +238,7 @@ class StorageManager:
         force_create_data_set: bool = False,
         metadata: Optional[Dict[str, str]] = None,
         exclude_provider_ids: Optional[List[int]] = None,
+        source: Optional[str] = None,
         on_provider_selected: Optional[Callable] = None,
         on_data_set_resolved: Optional[Callable] = None,
     ) -> List[StorageContext]:
@@ -250,15 +262,17 @@ class StorageManager:
         if self._sp_registry is None:
             raise ValueError("sp_registry required for smart context creation")
         
+        effective_source = source if source is not None else self._source
         options = StorageContextOptions(
             with_cdn=with_cdn,
             force_create_data_set=force_create_data_set,
             metadata=metadata,
             exclude_provider_ids=exclude_provider_ids,
+            source=effective_source,
             on_provider_selected=on_provider_selected,
             on_data_set_resolved=on_data_set_resolved,
         )
-        
+
         return StorageContext.create_contexts(
             chain=self._chain,
             private_key=self._private_key,

--- a/src/pynapse/synapse.py
+++ b/src/pynapse/synapse.py
@@ -18,11 +18,19 @@ from pynapse.warm_storage import AsyncWarmStorageService, SyncWarmStorageService
 
 
 class Synapse:
-    def __init__(self, web3: Web3, chain: Chain, account_address: str, private_key: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        web3: Web3,
+        chain: Chain,
+        account_address: str,
+        private_key: Optional[str] = None,
+        source: Optional[str] = None,
+    ) -> None:
         self._web3 = web3
         self._chain = chain
         self._account = account_address
         self._private_key = private_key
+        self._source = source
         self._payments = SyncPaymentsService(web3, chain, account_address, private_key)
         self._providers = SyncSPRegistryService(web3, chain, private_key)
         self._warm_storage = SyncWarmStorageService(web3, chain, private_key)
@@ -35,18 +43,31 @@ class Synapse:
             sp_registry=self._providers,
             warm_storage=self._warm_storage,
             retriever=self._retriever,
+            source=source,
         )
         self._session_registry = SyncSessionKeyRegistry(web3, chain, private_key)
         self._filbeam = FilBeamService(chain)
 
     @classmethod
-    def create(cls, rpc_url: str, chain: Chain | str | int = CALIBRATION, private_key: Optional[str] = None) -> "Synapse":
+    def create(
+        cls,
+        rpc_url: str,
+        chain: Chain | str | int = CALIBRATION,
+        private_key: Optional[str] = None,
+        source: Optional[str] = None,
+    ) -> "Synapse":
+        """Create a sync Synapse client.
+
+        ``source`` is an application identifier used to namespace datasets:
+        datasets tagged with a different source value are treated as distinct
+        and will not be reused across applications. Pass ``None`` to opt out.
+        """
         client = SyncEVMClient.from_rpc_url(rpc_url)
         chain_obj = as_chain(chain)
         if private_key is None:
             raise ValueError("private_key required to create Synapse")
         account = Account.from_key(private_key)
-        return cls(client.web3, chain_obj, account.address, private_key)
+        return cls(client.web3, chain_obj, account.address, private_key, source=source)
 
     @property
     def web3(self) -> Web3:
@@ -59,6 +80,11 @@ class Synapse:
     @property
     def account(self) -> str:
         return self._account
+
+    @property
+    def source(self) -> Optional[str]:
+        """Application identifier for dataset namespace isolation."""
+        return self._source
 
     @property
     def payments(self) -> SyncPaymentsService:
@@ -105,11 +131,19 @@ class AsyncSynapse:
         data = await synapse.storage.download(piece_cid)
     """
     
-    def __init__(self, web3: AsyncWeb3, chain: Chain, account_address: str, private_key: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        web3: AsyncWeb3,
+        chain: Chain,
+        account_address: str,
+        private_key: Optional[str] = None,
+        source: Optional[str] = None,
+    ) -> None:
         self._web3 = web3
         self._chain = chain
         self._account = account_address
         self._private_key = private_key
+        self._source = source
         self._payments = AsyncPaymentsService(web3, chain, account_address, private_key)
         self._providers = AsyncSPRegistryService(web3, chain, private_key)
         self._warm_storage = AsyncWarmStorageService(web3, chain, private_key)
@@ -122,31 +156,31 @@ class AsyncSynapse:
             sp_registry=self._providers,
             warm_storage=self._warm_storage,
             retriever=self._retriever,
+            source=source,
         )
         self._session_registry = AsyncSessionKeyRegistry(web3, chain, private_key)
         self._filbeam = FilBeamService(chain)
 
     @classmethod
     async def create(
-        cls, rpc_url: str, chain: Chain | str | int = CALIBRATION, private_key: Optional[str] = None
+        cls,
+        rpc_url: str,
+        chain: Chain | str | int = CALIBRATION,
+        private_key: Optional[str] = None,
+        source: Optional[str] = None,
     ) -> "AsyncSynapse":
-        """
-        Create an async Synapse client.
-        
-        Args:
-            rpc_url: RPC URL for the Filecoin chain
-            chain: Chain configuration (CALIBRATION, MAINNET, or chain ID)
-            private_key: Private key for signing transactions
-            
-        Returns:
-            Configured AsyncSynapse instance
+        """Create an async Synapse client.
+
+        ``source`` is an application identifier used to namespace datasets:
+        datasets tagged with a different source value are treated as distinct
+        and will not be reused across applications. Pass ``None`` to opt out.
         """
         client = AsyncEVMClient.from_rpc_url(rpc_url)
         chain_obj = as_chain(chain)
         if private_key is None:
             raise ValueError("private_key required to create AsyncSynapse")
         account = Account.from_key(private_key)
-        return cls(client.web3, chain_obj, account.address, private_key)
+        return cls(client.web3, chain_obj, account.address, private_key, source=source)
 
     @property
     def web3(self) -> AsyncWeb3:
@@ -159,6 +193,11 @@ class AsyncSynapse:
     @property
     def account(self) -> str:
         return self._account
+
+    @property
+    def source(self) -> Optional[str]:
+        """Application identifier for dataset namespace isolation."""
+        return self._source
 
     @property
     def payments(self) -> AsyncPaymentsService:

--- a/src/pynapse/utils/constants.py
+++ b/src/pynapse/utils/constants.py
@@ -9,6 +9,7 @@ METADATA_KEYS = {
     "WITH_CDN": "withCDN",
     "WITH_IPFS_INDEXING": "withIPFSIndexing",
     "IPFS_ROOT_CID": "ipfsRootCID",
+    "SOURCE": "source",
 }
 
 TIMING_CONSTANTS = {

--- a/src/pynapse/utils/metadata.py
+++ b/src/pynapse/utils/metadata.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, Optional
 
 from .constants import METADATA_KEYS
 
@@ -16,15 +16,25 @@ def metadata_matches(data_set_metadata: Dict[str, str], requested_metadata: Dict
     return True
 
 
-def combine_metadata(metadata: Dict[str, str] | None = None, with_cdn: bool | None = None) -> Dict[str, str]:
-    metadata = metadata or {}
-    if with_cdn is None or METADATA_KEYS["WITH_CDN"] in metadata:
-        return metadata
-    if with_cdn:
-        combined = dict(metadata)
-        combined[METADATA_KEYS["WITH_CDN"]] = ""
-        return combined
-    return metadata
+def combine_metadata(
+    metadata: Dict[str, str] | None = None,
+    with_cdn: bool | None = None,
+    source: Optional[str] = None,
+) -> Dict[str, str]:
+    """Combine user metadata with SDK-managed keys (``withCDN``, ``source``).
+
+    Each managed key is added only when its option is active AND the key is
+    not already present in ``metadata`` — explicit user metadata wins.
+    """
+    result = dict(metadata or {})
+
+    if with_cdn and METADATA_KEYS["WITH_CDN"] not in result:
+        result[METADATA_KEYS["WITH_CDN"]] = ""
+
+    if source and METADATA_KEYS["SOURCE"] not in result:
+        result[METADATA_KEYS["SOURCE"]] = source
+
+    return result
 
 
 def metadata_array_to_object(entries: list[tuple[str, str]]) -> Dict[str, str]:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -14,6 +14,6 @@ def test_combine_metadata_with_cdn():
 
 
 def test_combine_metadata_no_override():
-    base = {METADATA_KEYS["WITH_CDN"]: ""}
+    base = {METADATA_KEYS["WITH_CDN"]: "existing"}
     combined = combine_metadata(base, with_cdn=True)
-    assert combined is base
+    assert combined == base

--- a/tests/test_source_metadata.py
+++ b/tests/test_source_metadata.py
@@ -1,0 +1,42 @@
+"""Tests for dataset namespace isolation via the ``source`` metadata key."""
+
+from __future__ import annotations
+
+from pynapse.utils.constants import METADATA_KEYS
+from pynapse.utils.metadata import combine_metadata, metadata_matches
+
+
+def test_combine_metadata_adds_source_when_present():
+    result = combine_metadata({}, False, "my-app")
+    assert result == {METADATA_KEYS["SOURCE"]: "my-app"}
+
+
+def test_combine_metadata_skips_empty_source():
+    assert combine_metadata({}, False, None) == {}
+    assert combine_metadata({}, False, "") == {}
+
+
+def test_combine_metadata_preserves_existing_source():
+    base = {METADATA_KEYS["SOURCE"]: "explicit"}
+    assert combine_metadata(base, False, "override") == base
+
+
+def test_combine_metadata_with_cdn_and_source():
+    result = combine_metadata({}, True, "my-app")
+    assert result == {
+        METADATA_KEYS["WITH_CDN"]: "",
+        METADATA_KEYS["SOURCE"]: "my-app",
+    }
+
+
+def test_combine_metadata_does_not_mutate_input():
+    base = {"foo": "bar"}
+    combine_metadata(base, True, "my-app")
+    assert base == {"foo": "bar"}
+
+
+def test_metadata_matches_treats_different_sources_as_distinct():
+    a = {METADATA_KEYS["SOURCE"]: "app-a"}
+    b = {METADATA_KEYS["SOURCE"]: "app-b"}
+    assert not metadata_matches(a, b)
+    assert metadata_matches(a, a)


### PR DESCRIPTION
## Summary
Mirrors [FilOzone/synapse-sdk#647](https://github.com/FilOzone/synapse-sdk/pull/647).

- Adds `SOURCE` key to `METADATA_KEYS` (value: ``\"source\"``).
- Extends `combine_metadata(metadata, with_cdn, source)` so the SDK tags datasets with a `source` identifier when provided. Explicit user metadata still wins.
- Adds an optional `source` parameter on `Synapse`/`AsyncSynapse` (and their `create()` constructors), `StorageManager`/`AsyncStorageManager`, and `StorageContextOptions` so different applications sharing a wallet don't reuse each other's datasets.
- `get_context` / `get_contexts` accept a per-call `source` that overrides the client-level default.

Note: kept `source` optional (default `None`) rather than strictly required. Upstream TS requires it at the type level as a breaking migration; Python callers can pass `None` explicitly and we'll document that as the recommended migration path.

## Test plan
- [x] `uv run pytest` — 81 passed (6 new).