### PR TITLE
feat(warm-storage)!: rename get_approved_providers and add get_endorsed_provider_ids

### DIFF
--- a/src/pynapse/core/chains.py
+++ b/src/pynapse/core/chains.py
@@ -16,6 +16,7 @@ class ChainContracts:
     sp_registry: str
     session_key_registry: str
     pdp_verifier: str
+    provider_id_set: str
 
 
 @dataclass(frozen=True)
@@ -54,6 +55,7 @@ CONTRACTS_BY_NETWORK: Dict[str, ChainContracts] = {
         sp_registry=ADDRESSES["serviceProviderRegistryAddress"]["314"],
         session_key_registry=ADDRESSES["sessionKeyRegistryAddress"]["314"],
         pdp_verifier=ADDRESSES["pdpVerifierAddress"]["314"],
+        provider_id_set=ADDRESSES["providerIdSetAddress"]["314"],
     ),
     NETWORK_CALIBRATION: ChainContracts(
         multicall3="0xcA11bde05977b3631167028862bE2a173976CA11",
@@ -64,6 +66,7 @@ CONTRACTS_BY_NETWORK: Dict[str, ChainContracts] = {
         sp_registry=ADDRESSES["serviceProviderRegistryAddress"]["314159"],
         session_key_registry=ADDRESSES["sessionKeyRegistryAddress"]["314159"],
         pdp_verifier=ADDRESSES["pdpVerifierAddress"]["314159"],
+        provider_id_set=ADDRESSES["providerIdSetAddress"]["314159"],
     ),
 }
 

--- a/src/pynapse/warm_storage/service.py
+++ b/src/pynapse/warm_storage/service.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional
 from eth_account import Account
 from web3 import AsyncWeb3, Web3
 
-from pynapse.contracts import FWSS_ABI, FWSS_VIEW_ABI
+from pynapse.contracts import FWSS_ABI, FWSS_VIEW_ABI, PROVIDER_ID_SET_ABI
 from pynapse.core.chains import Chain
 
 
@@ -42,6 +42,9 @@ class SyncWarmStorageService:
         self._private_key = private_key
         self._fwss = web3.eth.contract(address=chain.contracts.warm_storage, abi=FWSS_ABI)
         self._view = web3.eth.contract(address=chain.contracts.warm_storage_state_view, abi=FWSS_VIEW_ABI)
+        self._endorsements = web3.eth.contract(
+            address=chain.contracts.provider_id_set, abi=PROVIDER_ID_SET_ABI
+        )
 
     def get_data_set(self, data_set_id: int) -> DataSetInfo:
         info = self._view.functions.getDataSet(data_set_id).call()
@@ -111,23 +114,34 @@ class SyncWarmStorageService:
     def proving_deadline(self, data_set_id: int) -> int:
         return int(self._view.functions.provingDeadline(data_set_id).call())
 
-    def get_approved_providers(self, offset: int = 0, limit: int = 0) -> List[int]:
-        """
-        Get approved provider IDs with optional pagination.
-        
-        Args:
-            offset: Starting index (0-based). Use 0 to start from beginning.
-            limit: Maximum number of providers to return. Use 0 to get all remaining providers.
-            
-        Returns:
-            List of approved provider IDs.
+    def get_approved_provider_ids(self, offset: int = 0, limit: int = 0) -> List[int]:
+        """Approved provider IDs, optionally paginated.
+
+        Mirrors upstream ``getApprovedProviderIds``. Pass ``offset=0, limit=0``
+        (the defaults) to get the full list.
         """
         providers = self._view.functions.getApprovedProviders(offset, limit).call()
         return [int(pid) for pid in providers]
 
     def get_approved_providers_length(self) -> int:
-        """Get the total count of approved providers."""
+        """Total count of approved providers."""
         return int(self._view.functions.getApprovedProvidersLength().call())
+
+    def get_endorsed_provider_ids(self) -> List[int]:
+        """Endorsed provider IDs from the ProviderIdSet contract.
+
+        Mirrors upstream ``getEndorsedProviderIds``. Deduplicates results — the
+        underlying set may return the same ID multiple times.
+        """
+        ids = self._endorsements.functions.getProviderIds().call()
+        seen: List[int] = []
+        visited: set[int] = set()
+        for pid in ids:
+            value = int(pid)
+            if value not in visited:
+                visited.add(value)
+                seen.append(value)
+        return seen
 
     def is_provider_approved(self, provider_id: int) -> bool:
         """Check if a provider is approved for the warm storage service."""
@@ -158,11 +172,6 @@ class SyncWarmStorageService:
         signed = self._web3.eth.account.sign_transaction(txn, private_key=self._private_key)
         tx_hash = self._web3.eth.send_raw_transaction(signed.rawTransaction)
         return tx_hash.hex()
-
-    def get_approved_provider_ids(self) -> List[int]:
-        """Get list of all approved provider IDs for the warm storage service."""
-        # Use the view contract's getApprovedProviders with offset=0, limit=0 to get all
-        return self.get_approved_providers(offset=0, limit=0)
 
     def get_active_piece_count(self, data_set_id: int) -> int:
         """Get count of active pieces in a dataset (excludes removed pieces)."""
@@ -281,6 +290,9 @@ class AsyncWarmStorageService:
         self._private_key = private_key
         self._fwss = web3.eth.contract(address=chain.contracts.warm_storage, abi=FWSS_ABI)
         self._view = web3.eth.contract(address=chain.contracts.warm_storage_state_view, abi=FWSS_VIEW_ABI)
+        self._endorsements = web3.eth.contract(
+            address=chain.contracts.provider_id_set, abi=PROVIDER_ID_SET_ABI
+        )
 
     async def get_data_set(self, data_set_id: int) -> DataSetInfo:
         info = await self._view.functions.getDataSet(data_set_id).call()
@@ -350,23 +362,34 @@ class AsyncWarmStorageService:
     async def proving_deadline(self, data_set_id: int) -> int:
         return int(await self._view.functions.provingDeadline(data_set_id).call())
 
-    async def get_approved_providers(self, offset: int = 0, limit: int = 0) -> List[int]:
-        """
-        Get approved provider IDs with optional pagination.
-        
-        Args:
-            offset: Starting index (0-based). Use 0 to start from beginning.
-            limit: Maximum number of providers to return. Use 0 to get all remaining providers.
-            
-        Returns:
-            List of approved provider IDs.
+    async def get_approved_provider_ids(self, offset: int = 0, limit: int = 0) -> List[int]:
+        """Approved provider IDs, optionally paginated.
+
+        Mirrors upstream ``getApprovedProviderIds``. Pass ``offset=0, limit=0``
+        (the defaults) to get the full list.
         """
         providers = await self._view.functions.getApprovedProviders(offset, limit).call()
         return [int(pid) for pid in providers]
 
     async def get_approved_providers_length(self) -> int:
-        """Get the total count of approved providers."""
+        """Total count of approved providers."""
         return int(await self._view.functions.getApprovedProvidersLength().call())
+
+    async def get_endorsed_provider_ids(self) -> List[int]:
+        """Endorsed provider IDs from the ProviderIdSet contract.
+
+        Mirrors upstream ``getEndorsedProviderIds``. Deduplicates results — the
+        underlying set may return the same ID multiple times.
+        """
+        ids = await self._endorsements.functions.getProviderIds().call()
+        seen: List[int] = []
+        visited: set[int] = set()
+        for pid in ids:
+            value = int(pid)
+            if value not in visited:
+                visited.add(value)
+                seen.append(value)
+        return seen
 
     async def is_provider_approved(self, provider_id: int) -> bool:
         """Check if a provider is approved for the warm storage service."""
@@ -397,11 +420,6 @@ class AsyncWarmStorageService:
         signed = Account.sign_transaction(txn, private_key=self._private_key)
         tx_hash = await self._web3.eth.send_raw_transaction(signed.rawTransaction)
         return tx_hash.hex()
-
-    async def get_approved_provider_ids(self) -> List[int]:
-        """Get list of all approved provider IDs for the warm storage service."""
-        # Use the view contract's getApprovedProviders with offset=0, limit=0 to get all
-        return await self.get_approved_providers(offset=0, limit=0)
 
     async def get_active_piece_count(self, data_set_id: int) -> int:
         """Get count of active pieces in a dataset (excludes removed pieces)."""

--- a/tests/test_warm_storage_rename.py
+++ b/tests/test_warm_storage_rename.py
@@ -1,0 +1,33 @@
+"""Tests for SP registry ID rename (#712) — mostly guards the new surface."""
+
+from __future__ import annotations
+
+from pynapse.warm_storage.service import AsyncWarmStorageService, SyncWarmStorageService
+
+
+def test_approved_provider_method_name_exists():
+    # The canonical name is get_approved_provider_ids; the old
+    # get_approved_providers shim has been removed.
+    assert hasattr(SyncWarmStorageService, "get_approved_provider_ids")
+    assert hasattr(AsyncWarmStorageService, "get_approved_provider_ids")
+    assert not hasattr(SyncWarmStorageService, "get_approved_providers")
+    assert not hasattr(AsyncWarmStorageService, "get_approved_providers")
+
+
+def test_endorsed_provider_method_exists():
+    assert hasattr(SyncWarmStorageService, "get_endorsed_provider_ids")
+    assert hasattr(AsyncWarmStorageService, "get_endorsed_provider_ids")
+
+
+def test_endorsed_provider_ids_dedupe_logic():
+    # Replicate the dedup loop in isolation: the service uses the same
+    # pattern to preserve insertion order while removing duplicates.
+    raw = [3, 1, 2, 1, 3, 5]
+    seen: list[int] = []
+    visited: set[int] = set()
+    for pid in raw:
+        value = int(pid)
+        if value not in visited:
+            visited.add(value)
+            seen.append(value)
+    assert seen == [3, 1, 2, 5]


### PR DESCRIPTION
## Summary
Mirrors [FilOzone/synapse-sdk#712](https://github.com/FilOzone/synapse-sdk/pull/712).

- Renames `get_approved_providers(offset, limit)` → `get_approved_provider_ids(offset, limit)` on both sync and async `WarmStorageService`. The old name was misleading since the method returns IDs, not full records. Redundant no-arg wrapper removed.
- Adds `get_endorsed_provider_ids()`, which reads the `ProviderIdSet` contract and deduplicates IDs while preserving insertion order.
- Adds `provider_id_set` to `ChainContracts` for both mainnet and calibration (already present in `addresses.json`).

## Breaking change
Callers of `warm_storage.get_approved_providers()` must switch to `warm_storage.get_approved_provider_ids()`.

## Test plan
- [x] `uv run pytest` — 84 passed (3 new).