### PR TITLE
feat(warm-storage): expose paginated client dataset queries

### DIFF
--- a/src/pynapse/warm_storage/service.py
+++ b/src/pynapse/warm_storage/service.py
@@ -64,9 +64,34 @@ class SyncWarmStorageService:
             data_set_id=int(info[10]),
         )
 
-    def get_client_data_sets(self, client_address: str) -> List[DataSetInfo]:
-        data_sets = self._view.functions.getClientDataSets(client_address).call()
+    def get_client_data_sets(
+        self, client_address: str, offset: int = 0, limit: int = 0
+    ) -> List[DataSetInfo]:
+        """Full dataset records for ``client_address``, optionally paginated.
+
+        Pass ``offset=0, limit=0`` (the defaults) for the full list. Uses the
+        view contract's paginated ``getClientDataSets`` overload under the
+        hood — match upstream ``getClientDataSets`` semantics.
+        """
+        data_sets = self._view.functions.getClientDataSets(
+            client_address, offset, limit
+        ).call()
         return [self.get_data_set(int(ds[10])) for ds in data_sets]
+
+    def get_client_data_set_ids(
+        self, client_address: str, offset: int = 0, limit: int = 0
+    ) -> List[int]:
+        """Dataset IDs for ``client_address``, optionally paginated."""
+        ids = self._view.functions.clientDataSets(
+            client_address, offset, limit
+        ).call()
+        return [int(data_set_id) for data_set_id in ids]
+
+    def get_client_data_sets_length(self, client_address: str) -> int:
+        """Total count of datasets owned by ``client_address``."""
+        return int(
+            self._view.functions.getClientDataSetsLength(client_address).call()
+        )
 
     def get_all_data_set_metadata(self, data_set_id: int) -> Dict[str, str]:
         entries = self._view.functions.getAllDataSetMetadata(data_set_id).call()
@@ -312,9 +337,29 @@ class AsyncWarmStorageService:
             data_set_id=int(info[10]),
         )
 
-    async def get_client_data_sets(self, client_address: str) -> List[DataSetInfo]:
-        data_sets = await self._view.functions.getClientDataSets(client_address).call()
+    async def get_client_data_sets(
+        self, client_address: str, offset: int = 0, limit: int = 0
+    ) -> List[DataSetInfo]:
+        """Full dataset records for ``client_address``, optionally paginated."""
+        data_sets = await self._view.functions.getClientDataSets(
+            client_address, offset, limit
+        ).call()
         return [await self.get_data_set(int(ds[10])) for ds in data_sets]
+
+    async def get_client_data_set_ids(
+        self, client_address: str, offset: int = 0, limit: int = 0
+    ) -> List[int]:
+        """Dataset IDs for ``client_address``, optionally paginated."""
+        ids = await self._view.functions.clientDataSets(
+            client_address, offset, limit
+        ).call()
+        return [int(data_set_id) for data_set_id in ids]
+
+    async def get_client_data_sets_length(self, client_address: str) -> int:
+        """Total count of datasets owned by ``client_address``."""
+        return int(
+            await self._view.functions.getClientDataSetsLength(client_address).call()
+        )
 
     async def get_all_data_set_metadata(self, data_set_id: int) -> Dict[str, str]:
         entries = await self._view.functions.getAllDataSetMetadata(data_set_id).call()

--- a/tests/test_client_datasets_pagination.py
+++ b/tests/test_client_datasets_pagination.py
@@ -1,0 +1,34 @@
+"""Tests for paginated client dataset queries (#717) — surface-level."""
+
+from __future__ import annotations
+
+from pynapse.warm_storage.service import AsyncWarmStorageService, SyncWarmStorageService
+
+
+def test_paginated_methods_exist_on_sync():
+    for name in (
+        "get_client_data_sets",
+        "get_client_data_set_ids",
+        "get_client_data_sets_length",
+    ):
+        assert hasattr(SyncWarmStorageService, name)
+
+
+def test_paginated_methods_exist_on_async():
+    for name in (
+        "get_client_data_sets",
+        "get_client_data_set_ids",
+        "get_client_data_sets_length",
+    ):
+        assert hasattr(AsyncWarmStorageService, name)
+
+
+def test_get_client_data_sets_accepts_offset_and_limit():
+    import inspect
+
+    params = inspect.signature(
+        SyncWarmStorageService.get_client_data_sets
+    ).parameters
+    assert "offset" in params and "limit" in params
+    assert params["offset"].default == 0
+    assert params["limit"].default == 0


### PR DESCRIPTION
## Summary
Mirrors [FilOzone/synapse-sdk#717](https://github.com/FilOzone/synapse-sdk/pull/717).

- `get_client_data_sets(client, offset=0, limit=0)` — now accepts pagination args and uses the paginated view overload.
- `get_client_data_set_ids(client, offset=0, limit=0)` — new, ID-only accessor backed by `clientDataSets`.
- `get_client_data_sets_length(client)` — new, returns the total count.

Available on both `SyncWarmStorageService` and `AsyncWarmStorageService`.

## Test plan
- [x] `uv run pytest` — 89 passed (3 new).