### PR TITLE
feat: batch of small upstream fixes (#615, #687, #701)

### DIFF
--- a/src/pynapse/sp_registry/pdp_capabilities.py
+++ b/src/pynapse/sp_registry/pdp_capabilities.py
@@ -53,10 +53,29 @@ def decode_pdp_capabilities(capabilities: Dict[str, str]) -> PDPOffering:
             ipni_peer_id = multibase.encode("base58btc", Web3.to_bytes(hexstr=peer_hex)).decode()
         except Exception:
             ipni_peer_id = None
+
+    known_keys = {
+        CAP_SERVICE_URL,
+        CAP_MIN_PIECE_SIZE,
+        CAP_MAX_PIECE_SIZE,
+        CAP_STORAGE_PRICE,
+        CAP_MIN_PROVING_PERIOD,
+        CAP_LOCATION,
+        CAP_PAYMENT_TOKEN,
+        CAP_IPNI_PIECE,
+        CAP_IPNI_IPFS,
+        CAP_IPNI_PEER_ID,
+        CAP_IPNI_PEER_ID_LEGACY,
+    }
+    extra_capabilities = {
+        key: value for key, value in capabilities.items() if key not in known_keys
+    }
+
     return PDPOffering(
         ipni_piece=ipni_piece,
         ipni_ipfs=ipni_ipfs,
         ipni_peer_id=ipni_peer_id,
+        extra_capabilities=extra_capabilities,
         **required,
     )
 

--- a/src/pynapse/sp_registry/types.py
+++ b/src/pynapse/sp_registry/types.py
@@ -41,6 +41,17 @@ class PDPOffering:
     ipni_piece: bool = False
     ipni_ipfs: bool = False
     ipni_peer_id: Optional[str] = None
+    # Non-standard capabilities returned by the SP. Preserved so downstream
+    # consumers can read SP-specific signals (e.g. "serviceStatus"). Mirrors
+    # FilOzone/synapse-sdk#687.
+    extra_capabilities: Dict[str, str] = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        if self.extra_capabilities is None:
+            # Use field default cautiously — dataclass doesn't allow dict
+            # factories when mixing with inherited fields downstream; set
+            # here instead.
+            object.__setattr__(self, "extra_capabilities", {})
 
 
 @dataclass

--- a/src/pynapse/storage/async_manager.py
+++ b/src/pynapse/storage/async_manager.py
@@ -119,6 +119,7 @@ class AsyncStorageManager:
         warm_storage: Optional["AsyncWarmStorageService"] = None,
         retriever: Optional["AsyncChainRetriever"] = None,
         source: Optional[str] = None,
+        with_cdn: bool = False,
     ) -> None:
         self._chain = chain
         self._private_key = private_key
@@ -126,6 +127,7 @@ class AsyncStorageManager:
         self._warm_storage = warm_storage
         self._retriever = retriever
         self._source = source
+        self._with_cdn = with_cdn
         self._default_context: Optional[AsyncStorageContext] = None
         self._context_cache: Dict[int, AsyncStorageContext] = {}  # provider_id -> context
 
@@ -133,6 +135,11 @@ class AsyncStorageManager:
     def source(self) -> Optional[str]:
         """Application identifier for dataset namespace isolation."""
         return self._source
+
+    @property
+    def with_cdn(self) -> bool:
+        """Default ``withCDN`` flag used when a per-call value isn't given."""
+        return self._with_cdn
 
     def create_context(
         self, 

--- a/src/pynapse/storage/manager.py
+++ b/src/pynapse/storage/manager.py
@@ -113,6 +113,7 @@ class StorageManager:
         warm_storage=None,
         retriever=None,
         source: Optional[str] = None,
+        with_cdn: bool = False,
     ) -> None:
         self._chain = chain
         self._private_key = private_key
@@ -120,6 +121,7 @@ class StorageManager:
         self._warm_storage = warm_storage
         self._retriever = retriever
         self._source = source
+        self._with_cdn = with_cdn
         self._default_context: Optional[StorageContext] = None
         self._context_cache: Dict[int, StorageContext] = {}  # provider_id -> context
 
@@ -127,6 +129,11 @@ class StorageManager:
     def source(self) -> Optional[str]:
         """Application identifier for dataset namespace isolation."""
         return self._source
+
+    @property
+    def with_cdn(self) -> bool:
+        """Default ``withCDN`` flag used when a per-call value isn't given."""
+        return self._with_cdn
 
     def create_context(
         self, 

--- a/src/pynapse/synapse.py
+++ b/src/pynapse/synapse.py
@@ -25,12 +25,14 @@ class Synapse:
         account_address: str,
         private_key: Optional[str] = None,
         source: Optional[str] = None,
+        with_cdn: bool = False,
     ) -> None:
         self._web3 = web3
         self._chain = chain
         self._account = account_address
         self._private_key = private_key
         self._source = source
+        self._with_cdn = with_cdn
         self._payments = SyncPaymentsService(web3, chain, account_address, private_key)
         self._providers = SyncSPRegistryService(web3, chain, private_key)
         self._warm_storage = SyncWarmStorageService(web3, chain, private_key)
@@ -44,6 +46,7 @@ class Synapse:
             warm_storage=self._warm_storage,
             retriever=self._retriever,
             source=source,
+            with_cdn=with_cdn,
         )
         self._session_registry = SyncSessionKeyRegistry(web3, chain, private_key)
         self._filbeam = FilBeamService(chain)
@@ -55,6 +58,7 @@ class Synapse:
         chain: Chain | str | int = CALIBRATION,
         private_key: Optional[str] = None,
         source: Optional[str] = None,
+        with_cdn: bool = False,
     ) -> "Synapse":
         """Create a sync Synapse client.
 
@@ -67,7 +71,14 @@ class Synapse:
         if private_key is None:
             raise ValueError("private_key required to create Synapse")
         account = Account.from_key(private_key)
-        return cls(client.web3, chain_obj, account.address, private_key, source=source)
+        return cls(
+            client.web3,
+            chain_obj,
+            account.address,
+            private_key,
+            source=source,
+            with_cdn=with_cdn,
+        )
 
     @property
     def web3(self) -> Web3:
@@ -85,6 +96,11 @@ class Synapse:
     def source(self) -> Optional[str]:
         """Application identifier for dataset namespace isolation."""
         return self._source
+
+    @property
+    def with_cdn(self) -> bool:
+        """Default ``withCDN`` flag for storage operations."""
+        return self._with_cdn
 
     @property
     def payments(self) -> SyncPaymentsService:
@@ -138,12 +154,14 @@ class AsyncSynapse:
         account_address: str,
         private_key: Optional[str] = None,
         source: Optional[str] = None,
+        with_cdn: bool = False,
     ) -> None:
         self._web3 = web3
         self._chain = chain
         self._account = account_address
         self._private_key = private_key
         self._source = source
+        self._with_cdn = with_cdn
         self._payments = AsyncPaymentsService(web3, chain, account_address, private_key)
         self._providers = AsyncSPRegistryService(web3, chain, private_key)
         self._warm_storage = AsyncWarmStorageService(web3, chain, private_key)
@@ -157,6 +175,7 @@ class AsyncSynapse:
             warm_storage=self._warm_storage,
             retriever=self._retriever,
             source=source,
+            with_cdn=with_cdn,
         )
         self._session_registry = AsyncSessionKeyRegistry(web3, chain, private_key)
         self._filbeam = FilBeamService(chain)
@@ -168,6 +187,7 @@ class AsyncSynapse:
         chain: Chain | str | int = CALIBRATION,
         private_key: Optional[str] = None,
         source: Optional[str] = None,
+        with_cdn: bool = False,
     ) -> "AsyncSynapse":
         """Create an async Synapse client.
 
@@ -180,7 +200,14 @@ class AsyncSynapse:
         if private_key is None:
             raise ValueError("private_key required to create AsyncSynapse")
         account = Account.from_key(private_key)
-        return cls(client.web3, chain_obj, account.address, private_key, source=source)
+        return cls(
+            client.web3,
+            chain_obj,
+            account.address,
+            private_key,
+            source=source,
+            with_cdn=with_cdn,
+        )
 
     @property
     def web3(self) -> AsyncWeb3:
@@ -198,6 +225,11 @@ class AsyncSynapse:
     def source(self) -> Optional[str]:
         """Application identifier for dataset namespace isolation."""
         return self._source
+
+    @property
+    def with_cdn(self) -> bool:
+        """Default ``withCDN`` flag for storage operations."""
+        return self._with_cdn
 
     @property
     def payments(self) -> AsyncPaymentsService:

--- a/src/pynapse/utils/metadata.py
+++ b/src/pynapse/utils/metadata.py
@@ -25,8 +25,15 @@ def combine_metadata(
 
     Each managed key is added only when its option is active AND the key is
     not already present in ``metadata`` — explicit user metadata wins.
+    Non-string metadata values raise ``TypeError`` with the offending key
+    (mirrors FilOzone/synapse-sdk#615).
     """
     result = dict(metadata or {})
+    for key, value in result.items():
+        if not isinstance(value, str):
+            raise TypeError(
+                f"Metadata value for key {key!r} must be a string, got {type(value).__name__}"
+            )
 
     if with_cdn and METADATA_KEYS["WITH_CDN"] not in result:
         result[METADATA_KEYS["WITH_CDN"]] = ""

--- a/tests/test_batch_small_fixes.py
+++ b/tests/test_batch_small_fixes.py
@@ -1,0 +1,65 @@
+"""Tests for the small-fixes batch (#615, #687, #701)."""
+
+from __future__ import annotations
+
+import pytest
+
+from pynapse.sp_registry.pdp_capabilities import decode_pdp_capabilities
+from pynapse.sp_registry.types import PDPOffering
+from pynapse.storage.async_manager import AsyncStorageManager
+from pynapse.storage.manager import StorageManager
+from pynapse.utils.metadata import combine_metadata
+
+
+def test_combine_metadata_rejects_non_string_value():
+    # Mirrors upstream #615 — a non-string value raises with the key name.
+    with pytest.raises(TypeError, match="foo"):
+        combine_metadata({"foo": 123})  # type: ignore[dict-item]
+
+
+def test_decode_pdp_capabilities_preserves_unknown_keys():
+    # #687 — preserve non-standard capabilities (serviceStatus etc.).
+    capabilities = {
+        "serviceURL": "0x" + "https://sp.example".encode().hex(),
+        "minPieceSizeInBytes": "0x" + (1024).to_bytes(32, "big").hex(),
+        "maxPieceSizeInBytes": "0x" + (10 * 1024 * 1024).to_bytes(32, "big").hex(),
+        "storagePricePerTibPerDay": "0x" + (1).to_bytes(32, "big").hex(),
+        "minProvingPeriodInEpochs": "0x" + (1).to_bytes(32, "big").hex(),
+        "location": "0x" + "us-east".encode().hex(),
+        "paymentTokenAddress": "0x" + "00" * 32,
+        # Non-standard capability that downstream dealbot etc. read.
+        "serviceStatus": "0x" + "ready".encode().hex(),
+        "customFlag": "0x01",
+    }
+    offering: PDPOffering = decode_pdp_capabilities(capabilities)
+    assert offering.extra_capabilities == {
+        "serviceStatus": "0x" + "ready".encode().hex(),
+        "customFlag": "0x01",
+    }
+
+
+class _DummyChain:
+    pass
+
+
+def test_storage_manager_exposes_source_and_with_cdn_getters():
+    # #701 — source and with_cdn should be readable on StorageManager.
+    manager = StorageManager(
+        chain=_DummyChain(),
+        private_key="0x" + "11" * 32,
+        source="my-app",
+        with_cdn=True,
+    )
+    assert manager.source == "my-app"
+    assert manager.with_cdn is True
+
+
+def test_async_storage_manager_exposes_source_and_with_cdn_getters():
+    manager = AsyncStorageManager(
+        chain=_DummyChain(),
+        private_key="0x" + "11" * 32,
+        source="other-app",
+        with_cdn=False,
+    )
+    assert manager.source == "other-app"
+    assert manager.with_cdn is False


### PR DESCRIPTION
## Summary
Batch-port of three small upstream fixes.

- **[#615](https://github.com/FilOzone/synapse-sdk/pull/615)**: `combine_metadata` raises `TypeError` with the offending key name when a metadata value isn't a string.
- **[#687](https://github.com/FilOzone/synapse-sdk/pull/687)**: `decode_pdp_capabilities` preserves non-standard SP-registry capabilities via a new `extra_capabilities` dict on `PDPOffering` — downstream consumers (e.g. dealbot's `serviceStatus`) can now see SP-specific signals we don't know about at SDK level.
- **[#701](https://github.com/FilOzone/synapse-sdk/pull/701)**: expose `source` and `with_cdn` as getters on `StorageManager` / `AsyncStorageManager`, and accept / expose `with_cdn` on `Synapse` / `AsyncSynapse` so callers can inspect SDK metadata defaults before hitting `combine_metadata`.

Other fixes from the original punch list were already handled or are N/A for pynapse:
- #616 (explicit allowances): pynapse's `approve_service` already requires explicit values.
- #643 (`asChain` preserves custom chain configs): pynapse's `as_chain` already returns Chain instances unchanged.
- #645 (session-key accountless reads): different architecture in pynapse.
- #702 (trim provider resolver): pynapse's resolver doesn't duplicate the invariant check.
- #723 (normalize empty pdp-verifier outputs): pynapse already surfaces empty results without the TS-side issues.

## Test plan
- [x] `uv run pytest` — 93 passed (5 new).