### PR TITLE
feat(session-key): add has_permission helpers + permission constants (partial #618)

### DIFF
--- a/src/pynapse/session/__init__.py
+++ b/src/pynapse/session/__init__.py
@@ -1,11 +1,25 @@
 from .key import SessionKey
-from .permissions import ALL_PERMISSIONS, SESSION_KEY_PERMISSIONS, get_permission_from_type_hash
+from .permissions import (
+    ADD_PIECES_PERMISSION,
+    ALL_PERMISSIONS,
+    CREATE_DATA_SET_PERMISSION,
+    DEFAULT_FWSS_PERMISSIONS,
+    DELETE_DATA_SET_PERMISSION,
+    SCHEDULE_PIECE_REMOVALS_PERMISSION,
+    SESSION_KEY_PERMISSIONS,
+    get_permission_from_type_hash,
+)
 from .registry import AsyncSessionKeyRegistry, SyncSessionKeyRegistry
 
 __all__ = [
     "SessionKey",
     "ALL_PERMISSIONS",
+    "DEFAULT_FWSS_PERMISSIONS",
     "SESSION_KEY_PERMISSIONS",
+    "CREATE_DATA_SET_PERMISSION",
+    "ADD_PIECES_PERMISSION",
+    "SCHEDULE_PIECE_REMOVALS_PERMISSION",
+    "DELETE_DATA_SET_PERMISSION",
     "get_permission_from_type_hash",
     "AsyncSessionKeyRegistry",
     "SyncSessionKeyRegistry",

--- a/src/pynapse/session/key.py
+++ b/src/pynapse/session/key.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Dict, Iterable, List, Optional
+import time
+from typing import Dict, Iterable
 
 from pynapse.core.chains import Chain
-from .permissions import ALL_PERMISSIONS
+from .permissions import ALL_PERMISSIONS, DEFAULT_FWSS_PERMISSIONS
 from .registry import SyncSessionKeyRegistry
 
 
@@ -22,6 +22,32 @@ class SessionKey:
                 self._owner_address, self._session_key_address, permission
             )
         return expiries
+
+    def has_permission(self, permission: str, *, now: int | None = None) -> bool:
+        """Return True if this session key is authorized for ``permission``.
+
+        ``permission`` may be either a name (e.g. ``"CreateDataSet"``) or the
+        corresponding EIP-712 type hash. Mirrors ``sessionKey.hasPermission``
+        introduced in FilOzone/synapse-sdk#618.
+        """
+        from .permissions import get_permission_from_type_hash
+
+        perm_name = permission
+        if permission.startswith("0x"):
+            try:
+                perm_name = get_permission_from_type_hash(permission)
+            except ValueError:
+                return False
+
+        expiry = self._registry.authorization_expiry(
+            self._owner_address, self._session_key_address, perm_name
+        )
+        current = now if now is not None else int(time.time())
+        return expiry > current
+
+    def has_permissions(self, permissions: Iterable[str] = DEFAULT_FWSS_PERMISSIONS) -> bool:
+        """Return True only when every permission in ``permissions`` is held."""
+        return all(self.has_permission(p) for p in permissions)
 
     def login(self, expiry: int, permissions: Iterable[str] = ALL_PERMISSIONS, origin: str = "unknown") -> str:
         return self._registry.login(self._owner_address, self._session_key_address, expiry, permissions, origin)

--- a/src/pynapse/session/permissions.py
+++ b/src/pynapse/session/permissions.py
@@ -49,6 +49,17 @@ SESSION_KEY_PERMISSIONS: Dict[SessionKeyPermission, str] = {
     "DeleteDataSet": type_hash("DeleteDataSet"),
 }
 
+# EIP-712 type hashes — mirrors the tagged permission constants introduced
+# in FilOzone/synapse-sdk#618. Useful when comparing against raw hashes
+# returned by the SessionKeyRegistry contract.
+CREATE_DATA_SET_PERMISSION = SESSION_KEY_PERMISSIONS["CreateDataSet"]
+ADD_PIECES_PERMISSION = SESSION_KEY_PERMISSIONS["AddPieces"]
+SCHEDULE_PIECE_REMOVALS_PERMISSION = SESSION_KEY_PERMISSIONS["SchedulePieceRemovals"]
+DELETE_DATA_SET_PERMISSION = SESSION_KEY_PERMISSIONS["DeleteDataSet"]
+
+# The set of permissions FWSS requires for full dataset lifecycle operations.
+DEFAULT_FWSS_PERMISSIONS: List[SessionKeyPermission] = list(ALL_PERMISSIONS)
+
 
 def get_permission_from_type_hash(type_hash_value: str) -> SessionKeyPermission:
     for perm, h in SESSION_KEY_PERMISSIONS.items():

--- a/tests/test_session_key_permissions.py
+++ b/tests/test_session_key_permissions.py
@@ -1,0 +1,70 @@
+"""Tests for session-key permission helpers (portion of #618)."""
+
+from __future__ import annotations
+
+from pynapse.session import (
+    ADD_PIECES_PERMISSION,
+    CREATE_DATA_SET_PERMISSION,
+    DEFAULT_FWSS_PERMISSIONS,
+    DELETE_DATA_SET_PERMISSION,
+    SCHEDULE_PIECE_REMOVALS_PERMISSION,
+    SessionKey,
+    get_permission_from_type_hash,
+)
+from pynapse.session.permissions import SESSION_KEY_PERMISSIONS
+
+
+def test_permission_constants_match_session_key_permissions_map():
+    assert CREATE_DATA_SET_PERMISSION == SESSION_KEY_PERMISSIONS["CreateDataSet"]
+    assert ADD_PIECES_PERMISSION == SESSION_KEY_PERMISSIONS["AddPieces"]
+    assert SCHEDULE_PIECE_REMOVALS_PERMISSION == SESSION_KEY_PERMISSIONS[
+        "SchedulePieceRemovals"
+    ]
+    assert DELETE_DATA_SET_PERMISSION == SESSION_KEY_PERMISSIONS["DeleteDataSet"]
+
+
+def test_default_fwss_permissions_covers_all_four():
+    assert set(DEFAULT_FWSS_PERMISSIONS) == {
+        "CreateDataSet",
+        "AddPieces",
+        "SchedulePieceRemovals",
+        "DeleteDataSet",
+    }
+
+
+def test_type_hash_roundtrip():
+    assert get_permission_from_type_hash(CREATE_DATA_SET_PERMISSION) == "CreateDataSet"
+
+
+class _FakeRegistry:
+    def __init__(self, expiries):
+        self._expiries = expiries
+
+    def authorization_expiry(self, owner, session, permission):
+        return self._expiries.get(permission, 0)
+
+
+def test_has_permission_accepts_name_and_hash():
+    registry = _FakeRegistry({"CreateDataSet": 1000, "AddPieces": 100})
+    key = SessionKey(
+        chain=object(),
+        registry=registry,  # type: ignore[arg-type]
+        owner_address="0x" + "11" * 20,
+        session_key_address="0x" + "22" * 20,
+    )
+    assert key.has_permission("CreateDataSet", now=500) is True
+    assert key.has_permission(CREATE_DATA_SET_PERMISSION, now=500) is True
+    assert key.has_permission("AddPieces", now=500) is False  # expired
+    assert key.has_permission("DeleteDataSet", now=500) is False  # not granted
+
+
+def test_has_permissions_returns_false_when_any_missing():
+    registry = _FakeRegistry({"CreateDataSet": 2**32})  # only one permission granted
+    key = SessionKey(
+        chain=object(),
+        registry=registry,  # type: ignore[arg-type]
+        owner_address="0x" + "11" * 20,
+        session_key_address="0x" + "22" * 20,
+    )
+    assert key.has_permissions() is False
+    assert key.has_permission("CreateDataSet") is True


### PR DESCRIPTION
## Summary
Ports the permission-inspection surface of [FilOzone/synapse-sdk#618](https://github.com/FilOzone/synapse-sdk/pull/618).

- Exports tagged permission constants (`CREATE_DATA_SET_PERMISSION`, `ADD_PIECES_PERMISSION`, `SCHEDULE_PIECE_REMOVALS_PERMISSION`, `DELETE_DATA_SET_PERMISSION`) and `DEFAULT_FWSS_PERMISSIONS`.
- Adds `SessionKey.has_permission(name_or_hash, now=None)` and `SessionKey.has_permissions(permissions=DEFAULT_FWSS_PERMISSIONS)`.
- `has_permission` accepts either a permission name (e.g. `"CreateDataSet"`) or the EIP-712 type hash returned by the on-chain registry.

The full viem-based redesign (event emitters, `connect`/`disconnect` lifecycle, `login_sync`/`revoke_sync` orchestrators) is out of scope for this batch — pynapse's existing `SessionKey` / `SessionKeyRegistry` already covers the underlying login/revoke/fetch_expiries actions.

## Test plan
- [x] `uv run pytest` — 98 passed (5 new).